### PR TITLE
chore(webpack): Update webpack to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "liftoff": "^2.3.0",
     "lodash": "^4.16.4",
     "minimist": "^1.2.0",
-    "webpack": "2.1.0-beta.25",
+    "webpack": "2.2.1",
     "webpack-dev-server": "v2.1.0-beta.9"
   },
   "devDependencies": {

--- a/src/frontend/routing.ts
+++ b/src/frontend/routing.ts
@@ -15,9 +15,6 @@ const routes: Routes = [
     component: RootContainerComponent,
     children: [
       {
-        path: ''
-      },
-      {
         path: 'preview/:experimentID/:caseID',
         component: PreviewContainerComponent
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export class ExperimentBuilder implements Experiment {
   private _callCount = 0;
 
   constructor(public name: string, public module?: NodeModule) {
-    this.id = `${module.id}`;
+    this.id = `exp${module ? module.id : ''}`;
   }
 
   case(description: string, config: CaseConfig): this {
@@ -40,4 +40,4 @@ export class ExperimentBuilder implements Experiment {
 
 export function experimentOn(component: string, module?: NodeModule): ExperimentBuilder {
   return new ExperimentBuilder(component, module);
-} 
+}


### PR DESCRIPTION
This allows `component-lab` to be used along with `@angular/cli@1.0.0-beta.31` which uses `weback@2.2.x`.

I had to add a few lines to the `component-lab.config.js` file:

```js
const NgCliWebpackConfig = require('@angular/cli/models/webpack-config').NgCliWebpackConfig;

module.exports = {
  /**
   * Webpack configuration object used to load your experiments
   */
  webpackConfig: new NgCliWebpackConfig({
    target: 'development',
  }).config,
  ...
}
```

And in my lab modules:

```js
import 'path/to/polyfills.ts';
```
