### PR TITLE
feat(server): Support custom devServer options

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,12 +6,28 @@ const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
+export interface DevServerConfig {
+  port?: number;
+  proxy?: any;
+  host?: string;
+  quiet?: boolean;
+  noInfo?: boolean;
+  watchOptions?: any;
+  https?: boolean | {key: any; cert: any; };
+}
+
 
 export function startServer(config: ComponentLabConfig, suite: string) {
-  const webpackConfig = config.webpackConfig;
-  const https = !!webpackConfig.devServer.https;
-  const host = webpackConfig.devServer?.host || config.host || "localhost";
-  const port = webpackConfig.devServer?.port || config.port || 8080;
+  const webpackConfig: any = config.webpackConfig;
+  const devServerConfig: DevServerConfig = webpackConfig.devServer;
+  let https = false,
+    host = config.host || "localhost",
+    port = config.port || 8080;
+  if (devServerConfig) {
+    https = !!devServerConfig.https;
+    host = devServerConfig.host || host;
+    port = devServerConfig.port || port;
+  }
   const includes = config.include || [];
 
   webpackConfig.entry = {
@@ -47,7 +63,7 @@ export function startServer(config: ComponentLabConfig, suite: string) {
       chunkModules: false  
     },
     inline: true
-  }, webpackConfig.devServer);
+  }, devServerConfig);
 
   const server = new WebpackDevServer(compiler, serverConfig);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,11 +9,14 @@ const path = require('path');
 
 export function startServer(config: ComponentLabConfig, suite: string) {
   const webpackConfig = config.webpackConfig;
+  const https = !!webpackConfig.devServer.https;
+  const host = webpackConfig.devServer?.host || config.host || "localhost";
+  const port = webpackConfig.devServer?.port || config.port || 8080;
   const includes = config.include || [];
 
   webpackConfig.entry = {
     main: [
-      `webpack-dev-server/client?http://${config.host}:${config.port}/`,
+      `webpack-dev-server/client?http${https?'s':''}://${host}:${port}/`,
       ...includes,
       config.suites[suite]
     ]
@@ -32,7 +35,7 @@ export function startServer(config: ComponentLabConfig, suite: string) {
     template: path.resolve(__dirname, '../index.html')
   }));
 
-  const serverConfig = {
+  const serverConfig = Object.assign({}, {
     historyApiFallback: true,
     stats: {
       assets: true,
@@ -44,12 +47,12 @@ export function startServer(config: ComponentLabConfig, suite: string) {
       chunkModules: false  
     },
     inline: true
-  };
+  }, webpackConfig.devServer);
 
   const server = new WebpackDevServer(compiler, serverConfig);
 
   return new Promise((resolve, reject) => {
-    server.listen(config.port, `${config.host}`, function(err, stats) {
+    server.listen(port, `${host}`, function(err, stats) {
       if (err) {
         console.error(err.stack || err);
         if (err.details) { console.error(err.details); }


### PR DESCRIPTION
My project needed some components running under https, so had to do some tweaking of the config setup and how the server config is initialised - now it's possible to inject custom https settings and change the host/port if needed.

Thanks for a great tool!